### PR TITLE
fix: Make runner work when invoked via cargo

### DIFF
--- a/runner/Cargo.toml
+++ b/runner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-aoc-zen-runner"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 repository = "https://github.com/proegssilb/aoc-zen-runner"
 homepage = "https://github.com/proegssilb/aoc-zen-runner"

--- a/runner/src/cli.rs
+++ b/runner/src/cli.rs
@@ -1,8 +1,14 @@
-use clap::{Parser, Subcommand};
+use clap::{Parser, Subcommand, Args};
 
 #[derive(Parser, Clone, Debug)]
 #[command(author, version, about, long_about = None)]
-pub struct Cli {
+pub enum Cli {
+    #[command(name = "aoc")]
+    Aoc(Aoc)
+}
+
+#[derive(Clone, Debug, Args)]
+pub struct Aoc {
     // TODO: Spec out a config file. If we need one.
     // /// Sets a custom config file
     // #[arg(short, long, value_name = "FILE")]

--- a/runner/src/commands.rs
+++ b/runner/src/commands.rs
@@ -14,7 +14,7 @@ use reqwest::{blocking::ClientBuilder, cookie::Jar, Url};
 use thiserror::Error;
 
 use crate::{
-    cli::{Cli, Commands},
+    cli::{Commands, Aoc},
     codegen::{add_day_to_package, add_package_to_workspace, generate_day_file, populate_year_package},
     iodomain::{
         cargo::{day_from_bin, year_from_package, WorkspaceMeta},
@@ -24,7 +24,7 @@ use crate::{
 
 const AUTH_MESSAGE: &str = "This command doesn't implement proper authenticaion yet. Use your browser to visit and log in to the AOC website, then copy the value of the 'session' cookie, and paste it here: ";
 
-pub fn login<T: BufRead, U: Write>(readfn: fn() -> T, writefn: fn() -> U, _cli: Cli) -> anyhow::Result<()> {
+pub fn login<T: BufRead, U: Write>(readfn: fn() -> T, writefn: fn() -> U, _cli: Aoc) -> anyhow::Result<()> {
     let (mut stdin, mut stdout) = (readfn(), writefn());
 
     let mut store = SessionFileCookieStore::new()?;
@@ -40,7 +40,7 @@ pub fn login<T: BufRead, U: Write>(readfn: fn() -> T, writefn: fn() -> U, _cli: 
     Ok(())
 }
 
-pub fn input<T: BufRead, U: Write>(readfn: fn() -> T, writefn: fn() -> U, cli: Cli) -> anyhow::Result<()> {
+pub fn input<T: BufRead, U: Write>(readfn: fn() -> T, writefn: fn() -> U, cli: Aoc) -> anyhow::Result<()> {
     println!("Attempting to download input file: {:?}", &cli);
     let store = SessionFileCookieStore::new()?;
     let stored_session = store.get_session_cookie()?;
@@ -114,7 +114,7 @@ pub fn input<T: BufRead, U: Write>(readfn: fn() -> T, writefn: fn() -> U, cli: C
     Ok(())
 }
 
-pub fn prepare<T: BufRead, U: Write>(readfn: fn() -> T, writefn: fn() -> U, _cli: Cli) -> anyhow::Result<()> {
+pub fn prepare<T: BufRead, U: Write>(readfn: fn() -> T, writefn: fn() -> U, _cli: Aoc) -> anyhow::Result<()> {
     // Figure out which day(s) we're prepping for
     // - In November, default to Dec 1 of the current year.
     // - In December, default to the current day before 11pm EST, and the next day after 11pm EST.
@@ -179,7 +179,7 @@ pub fn prepare<T: BufRead, U: Write>(readfn: fn() -> T, writefn: fn() -> U, _cli
     if stamp.day() == day && stamp.year() == year as i32 {
         let input_file = meta.get_input_file_for_day(&(year as u16), &(day as u8));
         if !input_file.exists() {
-            let input_args = Cli {
+            let input_args = Aoc {
                 verbose: 0,
                 day: Some(day as u8),
                 year: Some(year as u16),
@@ -207,7 +207,7 @@ enum RunError {
     YearNotFound,
 }
 
-pub fn run<T: BufRead, U: Write>(readfn: fn() -> T, writefn: fn() -> U, cli: Cli, cmd: &str) -> anyhow::Result<()> {
+pub fn run<T: BufRead, U: Write>(readfn: fn() -> T, writefn: fn() -> U, cli: Aoc, cmd: &str) -> anyhow::Result<()> {
     // Get some data together
     let data = WorkspaceMeta::load()
         .context("Failed to load data for the current cargo workspace. Are you in a crate or workspace?")?;
@@ -251,7 +251,7 @@ pub fn run<T: BufRead, U: Write>(readfn: fn() -> T, writefn: fn() -> U, cli: Cli
     let input_file = data.get_input_file_for_day(&year_num, &day_num);
     if !input_file.exists() {
         println!("Creating input file: {}", input_file);
-        let input_args = Cli {
+        let input_args = Aoc {
             verbose: 0,
             day: Some(day_num),
             year: Some(year_num),
@@ -280,6 +280,6 @@ pub fn run<T: BufRead, U: Write>(readfn: fn() -> T, writefn: fn() -> U, cli: Cli
     Ok(())
 }
 
-pub fn benchmark<T: BufRead, U: Write>(_readfn: fn() -> T, _writefn: fn() -> U, _cli: Cli) -> anyhow::Result<()> {
+pub fn benchmark<T: BufRead, U: Write>(_readfn: fn() -> T, _writefn: fn() -> U, _cli: Aoc) -> anyhow::Result<()> {
     todo!()
 }

--- a/runner/src/main.rs
+++ b/runner/src/main.rs
@@ -17,7 +17,7 @@ fn stdout_wrapper() -> impl Write {
 }
 
 fn main() -> anyhow::Result<()> {
-    let cli = Cli::parse();
+    let Cli::Aoc(cli) = Cli::parse();
 
     match &cli.command {
         Some(Commands::Login) => cmds::login(stdin_wrapper, stdout_wrapper, cli),

--- a/runner/tests/cmd/login.toml
+++ b/runner/tests/cmd/login.toml
@@ -1,3 +1,3 @@
 bin.name = "cargo-aoc"
-args = "login"
+args = "aoc login"
 fs.sandbox = true


### PR DESCRIPTION
Cargo apparently does some very specific things with the args when running subcommands. This fixes the issue.