### PR TITLE
fix: Prevent contradictory lints when using `aoc_case`

### DIFF
--- a/aoc-zen-runner-macros/src/lib.rs
+++ b/aoc-zen-runner-macros/src/lib.rs
@@ -48,7 +48,7 @@ pub fn aoc_case(attr: TokenStream, item: TokenStream) -> TokenStream {
     let p2 = args.expected_p2;
     let input = parse_macro_input!(item as ItemConst);
     let in_name = &input.ident;
-    let slug_str: String = format!("aoc_test_{}" , &input.ident.to_string().to_lowercase());
+    let slug_str: String = format!("aoc_test_{}", &input.ident.to_string().to_lowercase());
     let slug = Ident::new(&slug_str, input.ident.span());
 
     if let Some(exp_p2) = p2 {
@@ -325,4 +325,3 @@ fn gen_slow_microbench() -> proc_macro2::TokenStream {
         criterion_main!(benches);
     }
 }
-

--- a/aoc-zen-runner-macros/src/lib.rs
+++ b/aoc-zen-runner-macros/src/lib.rs
@@ -48,7 +48,7 @@ pub fn aoc_case(attr: TokenStream, item: TokenStream) -> TokenStream {
     let p2 = args.expected_p2;
     let input = parse_macro_input!(item as ItemConst);
     let in_name = &input.ident;
-    let slug_str: String = "aoc_test_".to_string() + input.ident.to_string().as_str();
+    let slug_str: String = format!("aoc_test_{}" , &input.ident.to_string().to_lowercase());
     let slug = Ident::new(&slug_str, input.ident.span());
 
     if let Some(exp_p2) = p2 {


### PR DESCRIPTION
While using `aoc_case` on a const in testing, you couldn't pick a name for the const without causing a lint. If it was uppercase, the name should have been lowercase. If it was lowercase, it should have been uppercase. This change causes the macro's output to change the case for its generated code, leaving the user free to name their const uppercase, as `rust-fmt` intends.